### PR TITLE
revert recommends, add falkon & konsole

### DIFF
--- a/lindroid_base.yaml
+++ b/lindroid_base.yaml
@@ -24,7 +24,6 @@ actions:
 
   - action: apt
     chroot: true
-    recommends: true
     description: install packages
     packages:
       - create-disp

--- a/lindroid_plasma.yaml
+++ b/lindroid_plasma.yaml
@@ -24,21 +24,18 @@ actions:
 
   - action: apt
     chroot: true
-    recommends: true
     description: install kde
     packages:
       - libqt6gui6-gles
-      - kde-baseapps
-      - kde-standard
-      - kde-inotify-survey
-      - kdeconnect
+      - kde-full
       - kwin-wayland
       - qtwayland5
       - maliit-keyboard
       - sddm-theme-debian-breeze
       - kwin-wayland
       - plasma-workspace
-      - firefox-esr
+      - falkon
+      - konsole
       - drihybris
       - kinfocenter
       - kscreen


### PR DESCRIPTION
For a working terminal and web browser out of box without networkmanager or other packages we do not want.